### PR TITLE
fix: build metrics on cloudflare pages

### DIFF
--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -3,3 +3,6 @@
 export default function handler(req, res) {
   res.status(200).json({ name: "John Doe" });
 }
+
+// https://nextjs.org/docs/app/building-your-application/rendering/edge-and-nodejs-runtimes
+export const runtime = 'edge';


### PR DESCRIPTION
PR add a fix to build metrics, Next.js based, on [Cloudflare Pages](https://developers.cloudflare.com/pages/framework-guides/nextjs/).

**Preview** - https://fix-build-on-cloudflare-page.metrics-1da.pages.dev

Without the changes, build fail
```shell
npx @cloudflare/next-on-pages@1
```
<details>
<summary>error</summary>

<img width="977" alt="Screenshot 2025-01-27 at 13 10 37" src="https://github.com/user-attachments/assets/93cdee69-0bae-415b-8346-14e88fd4db28" />
</details>